### PR TITLE
chore(flow): remove flow dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "homepage": "https://github.com/TechnologyAdvice/scripts#readme",
   "dependencies": {
     "bluebird": "^3.1.5",
-    "flow-bin": "^0.21.0",
     "shelljs": "^0.6.0",
     "yargs": "^3.32.0"
   }


### PR DESCRIPTION
This removes the flow dependency so that apps implementing `ta-scripts` can specify their desired flow version without having to bump `ta-scripts` itself.