### PR TITLE
Descope npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Create a CHANGELOG.md in the root of the project for the current build _user_ an
 
     $ ta-script circle_ci/create_changelog
 
-Private repo?  Add the `tadeploy` user's personal access token:
+Private repo?  Add a personal access token:
 
     $ ta-script circle_ci/create_changelog -t <token>
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a place to house your reusable scripts.
 
 ## Install
 
-    $ npm i @technologyadvice/ta-scripts -D
+    $ npm i ta-scripts -D
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@technologyadvice/ta-scripts",
+  "name": "ta-scripts",
   "version": "2.1.0",
   "description": "CI/CD scripts",
   "main": "index.js",


### PR DESCRIPTION
This is a public repo, used also in our open source projects.  Open source users cannot install modules if they are scoped to `@technologyadvice` unless they are given permissions to the npm org.

This PR removes the scoping.  This module will be published as `ta-scripts` instead.  Our machine user, @deweybot will own all npm packages.