### PR TITLE
Indexr, recursive auto index

### DIFF
--- a/lib/indexr.js
+++ b/lib/indexr.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * Recursively creates index.js files exporting all *.js files in each directory.
+ */
+const path = require('path')
+const Promise = require('bluebird')
+const del = require('del')
+const yargs = require('yargs')
+
+const fs = Promise.promisifyAll(require('fs'))
+const glob = Promise.promisify(require('glob'))
+
+const argv = yargs
+  .usage('$0 <directory> [options]')
+  .example('$0 src', 'Recursively creates index.js in src')
+  .demand(1)
+  .help('help')
+  .alias('h', 'help')
+  .argv
+
+const FLAG = '/* @indexr */'
+const HEADER = [
+  FLAG,
+  '/* eslint-disable */',
+  '',
+].join('\n')
+
+const findDirs = (dir) => glob(`${dir}/**/`, {
+  ignore: [
+    `./node_modules/**`,
+  ],
+})
+
+const findFiles = (dir) => glob(`${dir}/*.js`, {
+  ignore: [
+    '**/index.js',
+  ],
+})
+
+// resolve if missing index or existing index contains FLAG
+const getSafeIndexPath = (dir) => {
+  const indexPath = path.resolve(dir, 'index.js')
+  return fs.readFileAsync(indexPath, 'utf8')
+    .then(data => data.includes(FLAG) ? indexPath : null)
+    .catch(err => err && err.code === 'ENOENT' ? indexPath : null)
+}
+
+const createIndexFile = (dir) => {
+  return Promise.all([
+      findFiles(dir),
+      getSafeIndexPath(dir),
+    ])
+    .then(all => {
+      const files = all[0]
+      const safeIndexPath = all[1]
+
+      // skip if no safe index was found
+      if (!safeIndexPath) return Promise.resolve()
+
+      // remove abandoned index
+      if (safeIndexPath && !files.length) {
+        return del(safeIndexPath)
+      }
+
+      // write new index
+      const importNames = files.map(file => path.basename(file, '.js'))
+      const importStatements = importNames.map(name => `import ${name} from './${name}'`).join('\n')
+
+      const defaultExport = [
+        '',
+        'const defaultExport = {',
+        importNames.map(importName => `  ${importName},`).join('\n'),
+        '}',
+        '',
+        'export default defaultExport',
+      ].join('\n')
+
+      const contents = [HEADER, importStatements, defaultExport].join('\n')
+
+      console.log(path.normalize(`\n${dir}/index.js`))
+      console.log(importNames.map(x => `  - ${x}`).join('\n'))
+      return fs.writeFileAsync(safeIndexPath, contents)
+    })
+}
+
+// --------------------------------------
+// Run
+// --------------------------------------
+
+findDirs(argv._[0])
+  .then(dirs => Promise.all(dirs.map(createIndexFile)))
+  .catch(err => {
+    throw new Error(err)
+  })

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "homepage": "https://github.com/TechnologyAdvice/scripts#readme",
   "dependencies": {
-    "bluebird": "^3.1.5",
+    "bluebird": "^3.3.3",
+    "del": "^2.2.0",
     "shelljs": "^0.6.0",
     "yargs": "^3.32.0"
   }


### PR DESCRIPTION
### `$ ta-script lib/indexr ./src`

### Features

- Accepts a single directory argument.
- Recursively creates `index.js` files in every directory of that has `*.js` files.
- Only directories with `*.js` files get an `index.js`.
- `index.js` files without the `/* @indexr */` flag are never touched.
- `index.js` files in directories with no `*.js` files are auto removed.


### Example

Given:

```
/src
  /components
    avatar.js
  /utils
    count.js
    scrap.js
```

Running `ta-script lib/indexr src` yields:

```
/src
  /components
    index.js
    avatar.js
  /utils
    index.js
    count.js
    scrap.js
```

Where `index.js` files looks like this:

```js
/* @indexr */
/* eslint-disable */

import count from './count'
import scrap from './scrap'

const defaultExport = {
  count,
  scrap,
}

export default defaultExport
```