### PR TITLE
Fix aws/stage trailing slash

### DIFF
--- a/aws/stage.js
+++ b/aws/stage.js
@@ -123,7 +123,7 @@ const stage = (dir, repo, branch) => {
   sh.echo('...monkey patching html paths')
   indexFiles.forEach((file) => {
     cache[file] = sh.cat(file)
-    sh.sed('-i', pathRegExp, (group, g1, g2) => `${g1}/${stagedPath}/${g2}`, file)
+    sh.sed('-i', pathRegExp, (group, g1, g2) => `${g1}/${stagedPath}${g2 === '"' ? g2 : `/${g2}`}`, file)
   })
 
   // sync


### PR DESCRIPTION
When the staging script updates paths, it was adding trailing slashes where it shouldn't have been.  Now the staging path is prepended correctly.  See cases:

```
--------------- relative ---------------------------------------------------------------
href=""                  =>    href="/qa/src/unity/fix/history-basename"
href="foo"               =>    href="/qa/src/unity/fix/history-basename/foo"
href="baz.js"            =>    href="/qa/src/unity/fix/history-basename/baz.js"
href="foo/bar"           =>    href="/qa/src/unity/fix/history-basename/foo/bar"
--------------- trailing ---------------------------------------------------------------
href="foo/"              =>    href="/qa/src/unity/fix/history-basename/foo/"
href="foo/bar/"          =>    href="/qa/src/unity/fix/history-basename/foo/bar/"
--------------- absolute ---------------------------------------------------------------
href="/"                 =>    href="/qa/src/unity/fix/history-basename"
href="/foo"              =>    href="/qa/src/unity/fix/history-basename/foo"
href="/foo/bar"          =>    href="/qa/src/unity/fix/history-basename/foo/bar"
href="/baz.js"           =>    href="/qa/src/unity/fix/history-basename/baz.js"
href="/foo/baz.png"      =>    href="/qa/src/unity/fix/history-basename/foo/baz.png"
href="/foo/bar/baz.png"  =>    href="/qa/src/unity/fix/history-basename/foo/bar/baz.png"
------ absolute trailing ---------------------------------------------------------------
href="/foo/"             =>    href="/qa/src/unity/fix/history-basename/foo/"
href="/foo/bar/"         =>    href="/qa/src/unity/fix/history-basename/foo/bar/"
```