### PR TITLE
Add git checks to npm release

### DIFF
--- a/npm/release.sh
+++ b/npm/release.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# ensure git is latest clean branch
 # require npm user
 # bump package version
 # commit
@@ -12,28 +13,68 @@ usage() {
   echo "  Usage: bash $0 <major|minor|patch>"
 }
 
+print() {
+  echo "NPM RELEASE: $1"
+}
+
 run() {
   local version=$1
+
+  # ensure git is ready
+  local local_sha=$(git rev-parse @)
+  local remote_sha=$(git rev-parse @{u})
+  local base_sha=$(git merge-base @ @{u})
+
+  if [[ -n $(git status --porcelain) ]]; then
+    print "Commit or stash you changes before releasing"
+    exit 1
+  else
+    print "Working directory is clean"
+  fi
+
+  if [ $local_sha = $remote_sha ]; then
+    print "Local branch is up-to-date."
+  elif [ $local_sha = $base_sha ]; then
+    print "You need to pull changes before you can release."
+    exit 1
+  elif [ $remote_sha = $base_sha ]; then
+    print "You need to push changes before you can release."
+    exit 1
+  else
+    print "Your branch has diverged from the remote, you cannot release."
+    exit 1
+  fi
+
+  # ensure npm is ready
   local npm_user=$(npm whoami)
   local is_collaborator=$(npm access ls-collaborators | grep ".*$npm_user.*:.*write.*")
   local is_owner=$(npm owner ls | grep ".*$npm_user <.*")
 
-  if [[ "$npm_user" ]]; then
-    if [[ "$is_collaborator" ]] || [[ "$is_owner" ]]; then
-      echo "Publishing new $version version as $npm_user."
-      echo ""
-      npm version ${version}
-      git push
-      git push --follow-tags
-      npm publish
-    else
-      echo "$npm_user does not have NPM write access. Request access from one of these fine folk:"
-      echo ""
-      npm owner ls
-    fi
-  else
-    echo "You must be logged in to NPM to publish, run \"npm login\" first."
+  if ! [[ "$npm_user" ]]; then
+    print "You must be logged in to NPM to publish, run \"npm login\" first."
+    exit 1
   fi
+
+  if [[ -z "$is_collaborator" ]] && [[ -z "$is_owner" ]]; then
+    print "$npm_user is not an NPM owner or collaborator. Request access from:"
+    npm owner ls
+    exit 1
+  fi
+
+  # all checks out, publish
+  print "Publishing new $version version as $npm_user."
+
+  print "...npm version $version"
+  npm version ${version}
+
+  print "...git push"
+  git push
+
+  print "...git push --follow-tags"
+  git push --follow-tags
+
+  print "...npm publish"
+  npm publish
 }
 
 case $1 in


### PR DESCRIPTION
This PR adds a check to ensure the working tree is clean.  It also ensures you are on the latest version of the branch.  This prevents failures when releasing due to needing to push/pull changes.

Lastly, the script will now fail at any of the check points instead of powering through when it is obvious the release cannot continue.