### PR TITLE
fix(npm): fetch before release

### DIFF
--- a/npm/release.sh
+++ b/npm/release.sh
@@ -20,7 +20,8 @@ print() {
 run() {
   local version=$1
 
-  # ensure git is ready
+  # ensure git is ready, fetch before making comparisons
+  git fetch
   local local_sha=$(git rev-parse @)
   local remote_sha=$(git rev-parse @{u})
   local base_sha=$(git merge-base @ @{u})


### PR DESCRIPTION
The release script checks to make sure the local branch is clean, up to date, and has not diverged.  It does this against the FETCH_HEAD however.  This PR first fetches so the local FETCH_HEAD is up to date with the remote, then it does the checks.

Solves the case where a PR is merged on GH (master updated), then try to make a release of master locally before pulling/fetching.  You have no unpushed commits, your "up to date" with origin/master, and have not diverged.  But, the remote has updated!